### PR TITLE
fix the undefined "MAX" problem

### DIFF
--- a/src/chinadns.c
+++ b/src/chinadns.c
@@ -29,6 +29,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <sys/param.h>
 
 #include "config.h"
 


### PR DESCRIPTION
Fix https://github.com/clowwindy/ChinaDNS/issues/99
both uclibc and musl libc defines the MAX macro in sys/param.h, use this may fix the compile problem